### PR TITLE
added a half em

### DIFF
--- a/css/libheader7_lite_dropin.css
+++ b/css/libheader7_lite_dropin.css
@@ -9,7 +9,7 @@
 	line-height: 1.231;
 	width: 100%; 
 	margin-bottom: 1em; 
-	height: 2.7em; 
+	height: 3.2em; 
 	padding: 0 0 .3em;
 	background-color: #03314b;
 	border-bottom: 4px solid #b2a38f;


### PR DESCRIPTION
Noticed a little overlap between the logo and border here so I added a half em to the container height:
![screen shot 2015-07-01 at 3 09 43 pm](https://cloud.githubusercontent.com/assets/1715042/8462696/85ef6f7a-2003-11e5-9b40-b9e9c167171e.png)
